### PR TITLE
Cert-manager > Fix cert manager leader election and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ spec:
                 port:
                   number: 80
 ```
+## Cert-manager troubleshooting
+
+1. When deploying make sure api startup job completed correctly.
+2. In Some cases there might be issues with network when setting up the cluster, if it's failed try to check
+the webhook pod and check the logs.
+3. cert manager has complete https://cert-manager.io/docs/troubleshooting/webhook/ troubleshooting guide.
 
 # Grafana
 

--- a/variables.tf
+++ b/variables.tf
@@ -101,6 +101,6 @@ variable "prometheus_enabled" {
 }
 
 variable "cert_manager_leader_election_namespace" {
-  default     = "kube-system"
+  default     = "cert-manager"
   description = "The namespace used for the leader election lease. Change to cert-manager for GKE Autopilot"
 }


### PR DESCRIPTION
There are issues with GKE autopilot when we try to create/edit kube-system namespace, as this namespace is protected by Google. So we should use the cert-manager ns.

https://cert-manager.io/docs/troubleshooting/webhook/