### PR TITLE
Cert-manager > Option for resources

### DIFF
--- a/cert-manager.tf
+++ b/cert-manager.tf
@@ -15,6 +15,25 @@ resource "helm_release" "cert-manager" {
     value = var.cert_manager_leader_election_namespace
   }
 
+  dynamic "set" {
+      for_each = var.cert_manager_resources != null ? [1] : []
+  
+      content {
+        name = "global.resources"
+  
+        value = jsonencode({
+          requests = {
+            cpu    = var.cert_manager_resources.requests.cpu
+            memory = var.cert_manager_resources.requests.memory
+          }
+          limits = {
+            cpu    = var.cert_manager_resources.limits.cpu
+            memory = var.cert_manager_resources.limits.memory
+          }
+        })
+      }
+    }
+
   depends_on = [
     helm_release.nginx
   ]

--- a/variables.tf
+++ b/variables.tf
@@ -111,3 +111,17 @@ variable "cert_manager_leader_election_namespace" {
   default     = "cert-manager"
   description = "The namespace used for the leader election lease. Change to cert-manager for GKE Autopilot"
 }
+
+variable "cert_manager_resources" {
+  type = object({
+    requests = object({
+      cpu    = string
+      memory = string
+    })
+    limits = object({
+      cpu    = string
+      memory = string
+    })
+  })
+  default = null
+}


### PR DESCRIPTION
Cert manager doesn't have resources request and limit, so added option.

In GKE default resource is quite high, so we could save costs.